### PR TITLE
Introduced a unique constraint index for the user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,8 @@
                 "editor.fontSize": 12,
                 "editor.fontFamily": "'FiraCode Nerd Font Mono', 'Courier New', monospace",
                 "editor.lineNumbers": "relative",
-                "terminal.integrated.fontSize": 12
+                "terminal.integrated.fontSize": 12,
+                "editor.rulers": [80, 120]
             },
             "extensions": [
                 // Elixir

--- a/apps/privee/lib/privee/sessions.ex
+++ b/apps/privee/lib/privee/sessions.ex
@@ -22,14 +22,9 @@ defmodule Privee.Sessions do
   """
   def get_session_by_session_name_and_phrase(session_name, recovery_phrase)
       when is_binary(session_name) and is_binary(recovery_phrase) do
-    session = Repo.get_by(Session, recovery_phrase: String.trim(recovery_phrase))
+    session = Repo.get_by(Session, session_name: session_name)
 
-    if Session.valid_session_name?(session, session_name),
-      do:
-        session
-        # Manually putting the session name, as it is hashed in the database and
-        # it's not possible to retrieve it otherwise.
-        |> Map.put(:session_name, session_name)
+    if Session.valid_recovery_phrase?(session, recovery_phrase), do: session
   end
 
   @doc """
@@ -79,41 +74,6 @@ defmodule Privee.Sessions do
   """
   def change_session_registration(%Session{} = session, attrs \\ %{}) do
     Session.registration_changeset(session, attrs, hash_session_name: false)
-  end
-
-  ## Settings
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for changing the session recovery phrase.
-
-  ## Examples
-
-      iex> change_session_recovery-phrase(session)
-      %Ecto.Changeset{data: %Session{}}
-
-  """
-  def change_session_recovery_phrase(session, attrs \\ %{}) do
-    Session.recovery_phrase_changeset(session, attrs)
-  end
-
-  @doc """
-  Emulates that the recovery phrase will change without actually changing
-  it in the database.
-
-  ## Examples
-
-      iex> apply_session_recover_phrase(session, "valid session_name", %{recovery_phrase: ...})
-      {:ok, %Session{}}
-
-      iex> apply_session_email(session, "invalid session_name", %{email: ...})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def apply_session_recovery_phrase(session, session_name, attrs) do
-    session
-    |> Session.recovery_phrase_changeset(attrs)
-    |> Session.validate_current_session_name(session_name)
-    |> Ecto.Changeset.apply_action(:update)
   end
 
   ## Session

--- a/apps/privee/lib/privee/sessions/session.ex
+++ b/apps/privee/lib/privee/sessions/session.ex
@@ -9,24 +9,22 @@ defmodule Privee.Sessions.Session do
   @type t :: %__MODULE__{
           id: non_neg_integer(),
           session_name: String.t(),
-          hashed_session_name: String.t(),
           recovery_phrase: String.t(),
-          confirmed_at: NaiveDateTime.t(),
+          hashed_recovery_phrase: String.t(),
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }
 
   schema "sessions" do
-    field :session_name, :string, virtual: true, redact: true
-    field :hashed_session_name, :string, redact: true
-    field :recovery_phrase, :string
-    field :confirmed_at, :naive_datetime
+    field :session_name, :string
+    field :recovery_phrase, :string, virtual: true, redact: true
+    field :hashed_recovery_phrase, :string, redact: true
 
     timestamps()
   end
 
   @doc """
-  A session_name changeset for registration.
+  A changeset for registration.
 
   It is important to validate the length of the session name.
   Otherwise databases may truncate the session name without warnings, which
@@ -35,16 +33,16 @@ defmodule Privee.Sessions.Session do
 
   ## Options
 
-    * `:hash_session_name` - Hashes the session name so it can be stored securely
-      in the database and ensures the session name field is cleared to prevent
-      leaks in the logs. If session name hashing is not needed and clearing the
-      session name field is not desired (like when using this changeset for
+    * `:hash_recovery_phrase` - Hashes the recovery phrase so it can be stored securely
+      in the database and ensures the recovery_phrase field is cleared to prevent
+      leaks in the logs. If recovery phrase hashing is not needed and clearing the
+      recovery phrase field is not desired (like when using this changeset for
       validations on a LiveView form), this option can be set to `false`.
       Defaults to `true`.
 
-    * `:validate_session_name` - Validates the uniqueness of the session name, in case
-      you don't want to validate the uniqueness of the session name (like when
-      using this changeset for validations on a LiveView form before
+    * `:validate_recovery_phrase` - Validates the uniqueness of the recovery phrase,
+      in case you don't want to validate the uniqueness of the recovery phrase (like
+      when using this changeset for validations on a LiveView form before
       submitting the form), this option can be set to `false`.
       Defaults to `true`.
   """
@@ -52,7 +50,7 @@ defmodule Privee.Sessions.Session do
     session
     |> cast(attrs, [:session_name, :recovery_phrase])
     |> validate_session_name(opts)
-    |> validate_recovery_phrase()
+    |> validate_recovery_phrase(opts)
   end
 
   defp validate_session_name(changeset, opts) do
@@ -62,108 +60,57 @@ defmodule Privee.Sessions.Session do
     |> validate_format(:session_name, ~r/^[a-zA-Z0-9-]+$/,
       message: "must contain only alphanumeric characters and hyphens"
     )
-    |> maybe_hash_session_name(opts)
-
-    # #18
-    # |> validate_unique_session_name(opts)
+    |> validate_unique_session_name(opts)
   end
 
-  defp validate_recovery_phrase(changeset) do
+  defp validate_recovery_phrase(changeset, opts) do
     changeset
     |> validate_required([:recovery_phrase])
     |> validate_length(:recovery_phrase, min: 24, max: 160)
     |> validate_format(:recovery_phrase, ~r/^[a-zA-Z\s\.\,\;\:\!\?]+$/,
       message: "must contain only alphabetic characters and punctuation"
     )
+    |> maybe_hash_recovery_phrase(opts)
   end
 
-  defp maybe_hash_session_name(changeset, opts) do
-    hash_session_name? = Keyword.get(opts, :hash_session_name, true)
-    session_name = get_change(changeset, :session_name)
+  defp maybe_hash_recovery_phrase(changeset, opts) do
+    hash_recovery_phrase? = Keyword.get(opts, :hash_recovery_phrase, true)
+    recovery_phrase = get_change(changeset, :recovery_phrase)
 
-    if hash_session_name? && session_name && changeset.valid? do
+    if hash_recovery_phrase? && recovery_phrase && changeset.valid? do
       changeset
       # If using Bcrypt, then further validate it is at most 72 bytes long
-      |> validate_length(:session_name, max: 72, count: :bytes)
+      |> validate_length(:recovery_phrase, max: 72, count: :bytes)
       # Hashing could be done with `Ecto.Changeset.prepare_changes/2`, but that
       # would keep the database transaction open longer and hurt performance.
-      |> put_change(:hashed_session_name, Bcrypt.hash_pwd_salt(session_name))
-      |> delete_change(:session_name)
+      |> put_change(:hashed_recovery_phrase, Bcrypt.hash_pwd_salt(recovery_phrase))
+      |> delete_change(:recovery_phrase)
     else
       changeset
     end
   end
 
-  # #18 Evaluate the introduction of another field for uniqueness.
-  # defp validate_unique_session_name(changeset, opts) do
-  #   hash_session_name? = Keyword.get(opts, :hash_session_name, true)
-  #   if hash_session_name? do
-  #     changeset
-  #     |> maybe_hash_session_name([hash_session_name: true])
-  #     |> unsafe_validate_unique(:hashed_session_name, Privee.Repo)
-  #     |> unique_constraint(:hashed_session_name)
-  #   else
-  #     changeset
-  #   end
-  # end
-
-  @doc """
-  A session changeset for changing the recovery_phrase.
-
-  It requires the recovery_phrase to change otherwise an error is added.
-  """
-  def recovery_phrase_changeset(session, attrs) do
-    session
-    |> cast(attrs, [:recovery_phrase])
-    |> validate_recovery_phrase()
-    |> case do
-      %{changes: %{recovery_phrase: _}} = changeset -> changeset
-      %{} = changeset -> add_error(changeset, :recovery_phrase, "did not change")
-    end
+  defp validate_unique_session_name(changeset, _opts) do
+    changeset
+    |> unsafe_validate_unique(:session_name, Privee.Repo)
+    |> unique_constraint(:session_name)
   end
 
   @doc """
-  A session changeset for changing the session name.
+  Verifies the recovery phrase.
 
-  ## Options
-
-    * `:hash_session name` - Hashes the session name so it can be stored securely
-      in the database and ensures the session name field is cleared to prevent
-      leaks in the logs. If session name hashing is not needed and clearing the
-      session name field is not desired (like when using this changeset for
-      validations on a LiveView form), this option can be set to `false`.
-      Defaults to `true`.
-  """
-  def session_name_changeset(session, attrs, opts \\ []) do
-    session
-    |> cast(attrs, [:session_name])
-    |> validate_confirmation(:session_name, message: "does not match session name")
-    |> validate_session_name(opts)
-  end
-
-  @doc """
-  Confirms the account by setting `confirmed_at`.
-  """
-  def confirm_changeset(session) do
-    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-    change(session, confirmed_at: now)
-  end
-
-  @doc """
-  Verifies the session name.
-
-  If there is no session name or the session doesn't have a session name, we call
+  If there is no recovery phrase or the session doesn't have a recovery phrase, we call
   `Bcrypt.no_user_verify/0` to avoid timing attacks.
   """
-  def valid_session_name?(
-        %Privee.Sessions.Session{hashed_session_name: hashed_session_name},
-        session_name
+  def valid_recovery_phrase?(
+        %Privee.Sessions.Session{hashed_recovery_phrase: hashed_recovery_phrase},
+        recovery_phrase
       )
-      when is_binary(hashed_session_name) and byte_size(session_name) > 0 do
-    Bcrypt.verify_pass(session_name, hashed_session_name)
+      when is_binary(hashed_recovery_phrase) and byte_size(recovery_phrase) > 0 do
+    Bcrypt.verify_pass(recovery_phrase, hashed_recovery_phrase)
   end
 
-  def valid_session_name?(_, _) do
+  def valid_recovery_phrase?(_, _) do
     Bcrypt.no_user_verify()
     false
   end
@@ -171,11 +118,11 @@ defmodule Privee.Sessions.Session do
   @doc """
   Validates the current session otherwise adds an error to the changeset.
   """
-  def validate_current_session_name(changeset, session_name) do
-    if valid_session_name?(changeset.data, session_name) do
+  def validate_current_recovery_phrase(changeset, recovery_phrase) do
+    if valid_recovery_phrase?(changeset.data, recovery_phrase) do
       changeset
     else
-      add_error(changeset, :current_session_name, "is not valid")
+      add_error(changeset, :current_recovery_phrase, "is not valid")
     end
   end
 end

--- a/apps/privee/priv/repo/migrations/20240313112327_overhauling_session_table.exs
+++ b/apps/privee/priv/repo/migrations/20240313112327_overhauling_session_table.exs
@@ -1,0 +1,15 @@
+defmodule Privee.Repo.Migrations.OverhaulingSessionTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sessions) do
+      remove :hashed_session_name
+      remove :confirmed_at
+      remove :recovery_phrase
+
+      # Removing encryption to session name and adding it to the recovery field
+      add :session_name, :string, null: false
+      add :hashed_recovery_phrase, :citext, null: false
+    end
+  end
+end

--- a/apps/privee/priv/repo/migrations/20240313122224_add_unique_index_to_session_name.exs
+++ b/apps/privee/priv/repo/migrations/20240313122224_add_unique_index_to_session_name.exs
@@ -1,0 +1,7 @@
+defmodule Privee.Repo.Migrations.AddUniqueIndexToSessionName do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:sessions, [:session_name])
+  end
+end

--- a/apps/privee/test/privee/sessions_test.exs
+++ b/apps/privee/test/privee/sessions_test.exs
@@ -16,22 +16,16 @@ defmodule Privee.SessionsTest do
 
     test "does not return the session if the session_name is not valid" do
       session = session_fixture()
-      refute Sessions.get_session_by_session_name_and_phrase(session.recovery_phrase, "invalid")
+      refute Sessions.get_session_by_session_name_and_phrase(session.session_name, "invalid")
     end
 
     test "returns the session if the recovery phrase and session_name are valid" do
-      session_name = Ecto.UUID.generate()
+      %{id: id} = session = session_fixture()
 
-      %{id: id} =
-        session =
-        session_fixture(%{
-          session_name: session_name
-        })
-
-      assert %Session{id: ^id, session_name: ^session_name} =
+      assert %Session{id: ^id} =
                Sessions.get_session_by_session_name_and_phrase(
-                 session_name,
-                 session.recovery_phrase
+                 session.session_name,
+                 session_recovery_phrase()
                )
     end
   end
@@ -86,15 +80,14 @@ defmodule Privee.SessionsTest do
     end
 
     test "registers sessions with a hashed session_name" do
-      recovery_phrase = session_recovery_phrase()
+      session_name = unique_session_name()
 
       {:ok, session} =
-        Sessions.register_session(valid_session_attributes(recovery_phrase: recovery_phrase))
+        Sessions.register_session(valid_session_attributes(session_name: session_name))
 
-      assert session.recovery_phrase == recovery_phrase
-      assert is_binary(session.hashed_session_name)
-      assert is_nil(session.confirmed_at)
-      assert is_nil(session.session_name)
+      assert session.session_name == session_name
+      assert is_binary(session.session_name)
+      assert is_nil(session.recovery_phrase)
     end
   end
 
@@ -115,74 +108,8 @@ defmodule Privee.SessionsTest do
         )
 
       assert changeset.valid?
-      assert get_change(changeset, :recovery_phrase) == recovery_phrase
       assert get_change(changeset, :session_name) == session_name
-      assert is_nil(get_change(changeset, :hashed_session_name))
-    end
-  end
-
-  describe "change_session_recovery_phrase/2" do
-    test "returns a session changeset" do
-      assert %Ecto.Changeset{} = changeset = Sessions.change_session_recovery_phrase(%Session{})
-      assert changeset.required == [:recovery_phrase]
-    end
-  end
-
-  describe "apply_session_recovery_phrase/3" do
-    setup do
-      %{session: session_fixture()}
-    end
-
-    test "requires recovery_phrase to change", %{session: session} do
-      {:error, changeset} =
-        Sessions.apply_session_recovery_phrase(session, unique_session_name(), %{})
-
-      assert %{recovery_phrase: ["did not change"]} = errors_on(changeset)
-    end
-
-    test "validates recovery_phrase", %{session: session} do
-      {:error, changeset} =
-        Sessions.apply_session_recovery_phrase(session, unique_session_name(), %{
-          recovery_phrase: "not valid"
-        })
-
-      assert %{recovery_phrase: ["should be at least 24 character(s)"]} = errors_on(changeset)
-    end
-
-    test "validates maximum value for recovery_phrase for security", %{session: session} do
-      too_long = String.duplicate("db", 100)
-
-      {:error, changeset} =
-        Sessions.apply_session_recovery_phrase(session, unique_session_name(), %{
-          recovery_phrase: too_long
-        })
-
-      assert "should be at most 160 character(s)" in errors_on(changeset).recovery_phrase
-    end
-
-    test "validates current session_name", %{session: session} do
-      {:error, changeset} =
-        Sessions.apply_session_recovery_phrase(session, "!invalid", %{
-          recovery_phrase: session_recovery_phrase()
-        })
-
-      assert %{current_session_name: ["is not valid"]} = errors_on(changeset)
-    end
-
-    test "applies the recovery_phrase without persisting it" do
-      recovery_phrase = "The lazy dog jumps over the quick brown fox"
-      session_name = unique_session_name()
-
-      session =
-        session_fixture(%{recovery_phrase: session_recovery_phrase(), session_name: session_name})
-
-      {:ok, session} =
-        Sessions.apply_session_recovery_phrase(session, session_name, %{
-          recovery_phrase: recovery_phrase
-        })
-
-      assert session.recovery_phrase == recovery_phrase
-      assert Sessions.get_session!(session.id).recovery_phrase != recovery_phrase
+      assert get_change(changeset, :hashed_recovery_phrase)
     end
   end
 
@@ -196,11 +123,13 @@ defmodule Privee.SessionsTest do
       assert session_token = Repo.get_by(SessionToken, token: token)
       assert session_token.context == "session"
 
+      IO.puts("Passing")
+
       # Creating the same token for another session should fail
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%SessionToken{
           token: session_token.token,
-          session_id: session_fixture().id,
+          session_id: session_fixture(%{session_name: Ecto.UUID.generate}).id,
           context: "session"
         })
       end
@@ -239,8 +168,9 @@ defmodule Privee.SessionsTest do
   end
 
   describe "inspect/2 for the Session module" do
-    test "does not include session_name" do
-      refute inspect(%Session{session_name: "123456"}) =~ "session_name: \"123456\""
+    test "does not include recovery_phrase" do
+      recovery_phrase = "Some recovery phrase longer than twentyfour characters"
+      refute inspect(%Session{recovery_phrase: recovery_phrase}) =~ "session_name: \"#{recovery_phrase}\""
     end
   end
 end

--- a/apps/privee/test/privee/sessions_test.exs
+++ b/apps/privee/test/privee/sessions_test.exs
@@ -129,7 +129,7 @@ defmodule Privee.SessionsTest do
       assert_raise Ecto.ConstraintError, fn ->
         Repo.insert!(%SessionToken{
           token: session_token.token,
-          session_id: session_fixture(%{session_name: Ecto.UUID.generate}).id,
+          session_id: session_fixture(%{session_name: Ecto.UUID.generate()}).id,
           context: "session"
         })
       end
@@ -170,7 +170,9 @@ defmodule Privee.SessionsTest do
   describe "inspect/2 for the Session module" do
     test "does not include recovery_phrase" do
       recovery_phrase = "Some recovery phrase longer than twentyfour characters"
-      refute inspect(%Session{recovery_phrase: recovery_phrase}) =~ "session_name: \"#{recovery_phrase}\""
+
+      refute inspect(%Session{recovery_phrase: recovery_phrase}) =~
+               "session_name: \"#{recovery_phrase}\""
     end
   end
 end

--- a/apps/privee_web/lib/privee_web/session_auth.ex
+++ b/apps/privee_web/lib/privee_web/session_auth.ex
@@ -178,8 +178,8 @@ defmodule PriveeWeb.SessionAuth do
 
   defp mount_current_session(socket, session) do
     Phoenix.Component.assign_new(socket, :current_session, fn ->
-      if session_token = session["session_token"], do:
-        Sessions.get_session_by_session_token(session_token)
+      if session_token = session["session_token"],
+        do: Sessions.get_session_by_session_token(session_token)
     end)
   end
 

--- a/apps/privee_web/lib/privee_web/session_auth.ex
+++ b/apps/privee_web/lib/privee_web/session_auth.ex
@@ -36,7 +36,6 @@ defmodule PriveeWeb.SessionAuth do
     conn
     |> renew_session()
     |> put_token_in_session(token)
-    |> put_session_name_in_session(session.session_name)
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: session_return_to || signed_in_path(conn))
   end
@@ -96,7 +95,7 @@ defmodule PriveeWeb.SessionAuth do
   def fetch_current_session(conn, _opts) do
     {session_token, conn} = ensure_session_token(conn)
     session = session_token && Sessions.get_session_by_session_token(session_token)
-    assign(conn, :current_session, rebuild_session(conn, session))
+    assign(conn, :current_session, session)
   end
 
   defp ensure_session_token(conn) do
@@ -110,15 +109,6 @@ defmodule PriveeWeb.SessionAuth do
       else
         {nil, conn}
       end
-    end
-  end
-
-  defp rebuild_session(conn, session) do
-    if session_name = get_session(conn, :session_name) do
-      session
-      |> Map.put(:session_name, session_name)
-    else
-      session
     end
   end
 
@@ -188,16 +178,8 @@ defmodule PriveeWeb.SessionAuth do
 
   defp mount_current_session(socket, session) do
     Phoenix.Component.assign_new(socket, :current_session, fn ->
-      case {session["session_token"], session["session_name"]} do
-        {session_token, session_name}
-        when not is_nil(session_token) and not is_nil(session_name) ->
-          session_token
-          |> Sessions.get_session_by_session_token()
-          |> Map.put(:session_name, session_name)
-
-        _ ->
-          nil
-      end
+      if session_token = session["session_token"], do:
+        Sessions.get_session_by_session_token(session_token)
     end)
   end
 
@@ -236,13 +218,6 @@ defmodule PriveeWeb.SessionAuth do
     conn
     |> put_session(:session_token, token)
     |> put_session(:live_socket_id, "sessions_sessions:#{Base.url_encode64(token)}")
-  end
-
-  # Putting the session name in the session is required as it will be hashed on the database, and it won't be
-  # possiblle to fetch it back again.
-  defp put_session_name_in_session(conn, session_name) do
-    conn
-    |> put_session(:session_name, session_name)
   end
 
   defp maybe_store_return_to(%{method: "GET"} = conn) do

--- a/apps/privee_web/test/privee_web/controllers/session_controller_test.exs
+++ b/apps/privee_web/test/privee_web/controllers/session_controller_test.exs
@@ -12,8 +12,8 @@ defmodule PriveeWeb.SessionControllerTest do
       conn =
         post(conn, ~p"/sessions/log_in", %{
           "session" => %{
-            "recovery_phrase" => session.recovery_phrase,
-            "session_name" => unique_session_name()
+            "recovery_phrase" => session_recovery_phrase(),
+            "session_name" => session.session_name
           }
         })
 
@@ -31,8 +31,8 @@ defmodule PriveeWeb.SessionControllerTest do
       conn =
         post(conn, ~p"/sessions/log_in", %{
           "session" => %{
-            "recovery_phrase" => session.recovery_phrase,
-            "session_name" => unique_session_name(),
+            "recovery_phrase" => session_recovery_phrase(),
+            "session_name" => session.session_name,
             "remember_me" => "true"
           }
         })
@@ -47,8 +47,8 @@ defmodule PriveeWeb.SessionControllerTest do
         |> init_test_session(session_return_to: "/foo/bar")
         |> post(~p"/sessions/log_in", %{
           "session" => %{
-            "recovery_phrase" => session.recovery_phrase,
-            "session_name" => unique_session_name()
+            "recovery_phrase" => session_recovery_phrase(),
+            "session_name" => session.session_name
           }
         })
 
@@ -62,8 +62,8 @@ defmodule PriveeWeb.SessionControllerTest do
         |> post(~p"/sessions/log_in", %{
           "_action" => "registered",
           "session" => %{
-            "recovery_phrase" => session.recovery_phrase,
-            "session_name" => unique_session_name()
+            "recovery_phrase" => session_recovery_phrase(),
+            "session_name" => session.session_name
           }
         })
 

--- a/apps/privee_web/test/privee_web/live/session_login_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_login_live_test.exs
@@ -27,7 +27,7 @@ defmodule PriveeWeb.SessionLoginLiveTest do
     test "redirects if session login with valid credentials", %{conn: conn} do
       recovery_phrase = session_recovery_phrase()
       session_name = unique_session_name()
-      session = session_fixture(%{session_name: session_name, recovery_phrase: recovery_phrase})
+      _session = session_fixture(%{session_name: session_name, recovery_phrase: recovery_phrase})
 
       {:ok, lv, _html} = live(conn, ~p"/")
 

--- a/apps/privee_web/test/privee_web/live/session_login_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_login_live_test.exs
@@ -25,15 +25,16 @@ defmodule PriveeWeb.SessionLoginLiveTest do
 
   describe "session login" do
     test "redirects if session login with valid credentials", %{conn: conn} do
+      recovery_phrase = session_recovery_phrase()
       session_name = unique_session_name()
-      session = session_fixture(%{session_name: session_name})
+      session = session_fixture(%{session_name: session_name, recovery_phrase: recovery_phrase})
 
       {:ok, lv, _html} = live(conn, ~p"/")
 
       form =
         form(lv, "#login_form",
           session: %{
-            recovery_phrase: session.recovery_phrase,
+            recovery_phrase: recovery_phrase,
             session_name: session_name,
             remember_me: true
           }

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -64,21 +64,20 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
       assert response =~ "Log out"
     end
 
-    # #18
-    # test "renders errors for duplicated session name", %{conn: conn} do
-    #   {:ok, lv, _html} = live(conn, ~p"/sessions/register")
+    test "renders errors for duplicated session name", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/sessions/register")
 
-    #   _session = session_fixture(%{session_name: unique_session_name()})
+      _session = session_fixture(%{session_name: unique_session_name()})
 
-    #   result =
-    #     lv
-    #     |> form("#registration_form",
-    #       session: %{"recovery_phrase" => session_recovery_phrase(), "session_name" => unique_session_name()}
-    #     )
-    #     |> render_submit()
+      result =
+        lv
+        |> form("#registration_form",
+          session: %{"recovery_phrase" => session_recovery_phrase(), "session_name" => unique_session_name()}
+        )
+        |> render_submit()
 
-    #   assert result =~ "has already been taken"
-    # end
+      assert result =~ "has already been taken"
+    end
   end
 
   describe "registration navigation" do

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -72,7 +72,10 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
       result =
         lv
         |> form("#registration_form",
-          session: %{"recovery_phrase" => session_recovery_phrase(), "session_name" => unique_session_name()}
+          session: %{
+            "recovery_phrase" => session_recovery_phrase(),
+            "session_name" => unique_session_name()
+          }
         )
         |> render_submit()
 


### PR DESCRIPTION
Overhauled the session registration for every user:

- The session name, having that it's simply a GUID without any relevance or connection to the user, will not be hashed.
- The recovery phrase **will** be hashed, as it's something potentially related to the user.
- A unique index has been added to the `session_name`, so that the user will be able to select a unique one.