### PR TITLE
Added session name auto generation

### DIFF
--- a/apps/privee/lib/privee/session_name_provider.ex
+++ b/apps/privee/lib/privee/session_name_provider.ex
@@ -1,0 +1,57 @@
+defmodule Privee.SessionNameProvider do
+  @moduledoc """
+  This module implements getting a fresh unique session name by checking the
+  database in the real implementation, while it will return a constant value
+  in the test environment.
+  """
+
+  @provider_implementation Application.compile_env(:privee, :session_name_provider)
+
+  defmodule Behaviour do
+    @callback generate_new_available_session_name() :: {:ok, String.t()} | {:error, String.t()}
+  end
+
+  @doc """
+  Returns a fresh unique session name.
+  """
+  def generate_new_available_session_name() do
+    case @provider_implementation do
+      nil -> {:error, "No implementation for Privee.SessionNameProvider.Behaviour"}
+      module -> module.generate_new_available_session_name()
+    end
+  end
+end
+
+defmodule Privee.SessionNameProvider.Impl do
+  @moduledoc """
+  This module will be used in production, it calls the implementation in the
+  `Privee.Sessions` module to get a unique session name.
+  """
+
+  @behaviour Privee.SessionNameProvider.Behaviour
+
+  alias Privee.Sessions
+
+  def generate_new_available_session_name() do
+    {:ok, Sessions.generate_new_available_session_name()}
+  end
+end
+
+defmodule Privee.SessionNameProvider.Test do
+  @moduledoc """
+  This module will be used in the test environment, it returns a constant value.
+  """
+
+  @behaviour Privee.SessionNameProvider.Behaviour
+
+  @mocked_unique_session_name "ed833bb9-4860-4ca4-9bd7-ed7a0093be26"
+
+  @doc """
+  Returns the mocked value of the session name used by the module.
+  """
+  def get_mocked_unique_session_name, do: @mocked_unique_session_name
+
+  def generate_new_available_session_name() do
+    {:ok, @mocked_unique_session_name}
+  end
+end

--- a/apps/privee/lib/privee/session_name_provider.ex
+++ b/apps/privee/lib/privee/session_name_provider.ex
@@ -8,50 +8,54 @@ defmodule Privee.SessionNameProvider do
   @provider_implementation Application.compile_env(:privee, :session_name_provider)
 
   defmodule Behaviour do
+    @moduledoc """
+    This behaviour abstract the session name provider implementation for
+    mocking testing purpose.
+    """
     @callback generate_new_available_session_name() :: {:ok, String.t()} | {:error, String.t()}
   end
 
   @doc """
   Returns a fresh unique session name.
   """
-  def generate_new_available_session_name() do
+  def generate_new_available_session_name do
     case @provider_implementation do
       nil -> {:error, "No implementation for Privee.SessionNameProvider.Behaviour"}
       module -> module.generate_new_available_session_name()
     end
   end
-end
 
-defmodule Privee.SessionNameProvider.Impl do
-  @moduledoc """
-  This module will be used in production, it calls the implementation in the
-  `Privee.Sessions` module to get a unique session name.
-  """
+  defmodule Impl do
+    @moduledoc """
+    This module will be used in production, it calls the implementation in the
+    `Privee.Sessions` module to get a unique session name.
+    """
 
-  @behaviour Privee.SessionNameProvider.Behaviour
+    @behaviour Privee.SessionNameProvider.Behaviour
 
-  alias Privee.Sessions
+    alias Privee.Sessions
 
-  def generate_new_available_session_name() do
-    {:ok, Sessions.generate_new_available_session_name()}
+    def generate_new_available_session_name do
+      {:ok, Sessions.generate_new_available_session_name()}
+    end
   end
-end
 
-defmodule Privee.SessionNameProvider.Test do
-  @moduledoc """
-  This module will be used in the test environment, it returns a constant value.
-  """
+  defmodule Test do
+    @moduledoc """
+    This module will be used in the test environment, it returns a constant value.
+    """
 
-  @behaviour Privee.SessionNameProvider.Behaviour
+    @behaviour Privee.SessionNameProvider.Behaviour
 
-  @mocked_unique_session_name "ed833bb9-4860-4ca4-9bd7-ed7a0093be26"
+    @mocked_unique_session_name "ed833bb9-4860-4ca4-9bd7-ed7a0093be26"
 
-  @doc """
-  Returns the mocked value of the session name used by the module.
-  """
-  def get_mocked_unique_session_name, do: @mocked_unique_session_name
+    @doc """
+    Returns the mocked value of the session name used by the module.
+    """
+    def get_mocked_unique_session_name, do: @mocked_unique_session_name
 
-  def generate_new_available_session_name() do
-    {:ok, @mocked_unique_session_name}
+    def generate_new_available_session_name do
+      {:ok, @mocked_unique_session_name}
+    end
   end
 end

--- a/apps/privee/lib/privee/session_name_provider.ex
+++ b/apps/privee/lib/privee/session_name_provider.ex
@@ -19,10 +19,7 @@ defmodule Privee.SessionNameProvider do
   Returns a fresh unique session name.
   """
   def generate_new_available_session_name do
-    case @provider_implementation do
-      nil -> {:error, "No implementation for Privee.SessionNameProvider.Behaviour"}
-      module -> module.generate_new_available_session_name()
-    end
+    @provider_implementation.generate_new_available_session_name()
   end
 
   defmodule Impl do

--- a/apps/privee/lib/privee/sessions.ex
+++ b/apps/privee/lib/privee/sessions.ex
@@ -79,6 +79,26 @@ defmodule Privee.Sessions do
   def get_session_by_session_name(session_name),
     do: Repo.get_by(Session, session_name: session_name)
 
+  @doc """
+  Generates a new session name available, i.e. non currently existing on the database.
+  """
+  def generate_new_available_session_name do
+    new_session_name = Ecto.UUID.generate()
+
+    if session_name_exists?(new_session_name) do
+      generate_new_available_session_name()
+    else
+      new_session_name
+    end
+  end
+
+  defp session_name_exists?(session_name) do
+    Session
+    |> from()
+    |> where([s], s.session_name == ^session_name)
+    |> Repo.exists?()
+  end
+
   ## Session registration
 
   @doc """
@@ -109,7 +129,7 @@ defmodule Privee.Sessions do
 
   """
   def change_session_registration(%Session{} = session, attrs \\ %{}) do
-    Session.registration_changeset(session, attrs, hash_session_name: false)
+    Session.registration_changeset(session, attrs, hash_recovery_phrase: false)
   end
 
   ## Session
@@ -164,13 +184,6 @@ defmodule Privee.Sessions do
         do: [],
         else: [{field, "The session name does not exist"}]
     end)
-  end
-
-  defp session_name_exists?(session_name) do
-    Session
-    |> from()
-    |> where([s], s.session_name == ^session_name)
-    |> Repo.exists?()
   end
 
   @doc """

--- a/apps/privee/test/privee/sessions_test.exs
+++ b/apps/privee/test/privee/sessions_test.exs
@@ -1,9 +1,9 @@
 defmodule Privee.SessionsTest do
   use Privee.DataCase
 
-  alias Privee.Sessions
-
   import Privee.SessionsFixtures
+
+  alias Privee.Sessions
   alias Privee.Sessions.{PriveeForm, Session, SessionToken}
 
   describe "get_session_by_session_name_and_phrase/2" do
@@ -64,6 +64,13 @@ defmodule Privee.SessionsTest do
 
       assert %Session{session_name: ^session_name} =
                Sessions.get_session_by_session_name(session_name)
+    end
+  end
+
+  describe "generate_new_available_session_name/0" do
+    test "generates a new session name" do
+      assert session_name = Sessions.generate_new_available_session_name()
+      assert String.match?(session_name, ~r/^[a-z0-9-]{24,72}$/)
     end
   end
 
@@ -133,7 +140,7 @@ defmodule Privee.SessionsTest do
 
       assert changeset.valid?
       assert get_change(changeset, :session_name) == session_name
-      assert get_change(changeset, :hashed_recovery_phrase)
+      assert get_change(changeset, :recovery_phrase) == recovery_phrase
     end
   end
 

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
@@ -100,13 +100,17 @@ defmodule PriveeWeb.Chat.ChatLive do
          %{assigns: %{current_session: current_session, selected_session: selected_session}} =
            socket
        ) do
-    with :ok <- Events.subscribe_to_chat_events(socket, current_session.id, selected_session.id),
-         :ok <- Events.subscribe_to_receiving_events(socket, current_session.id) do
-      socket
-    else
-      error ->
-        Logger.warning("Failed to subscribe to chat events: '#{inspect(error)}'.")
+    if connected?(socket) do
+      with :ok <- Events.subscribe_to_chat_events(socket, current_session.id, selected_session.id),
+          :ok <- Events.subscribe_to_receiving_events(socket, current_session.id) do
         socket
+      else
+        error ->
+          Logger.warning("Failed to subscribe to chat events: '#{inspect(error)}'.")
+          socket
+      end
+    else
+      socket
     end
   end
 

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
@@ -101,8 +101,9 @@ defmodule PriveeWeb.Chat.ChatLive do
            socket
        ) do
     if connected?(socket) do
-      with :ok <- Events.subscribe_to_chat_events(socket, current_session.id, selected_session.id),
-          :ok <- Events.subscribe_to_receiving_events(socket, current_session.id) do
+      with :ok <-
+             Events.subscribe_to_chat_events(socket, current_session.id, selected_session.id),
+           :ok <- Events.subscribe_to_receiving_events(socket, current_session.id) do
         socket
       else
         error ->

--- a/apps/privee_web/lib/privee_web/live/privee_selector_live.ex
+++ b/apps/privee_web/lib/privee_web/live/privee_selector_live.ex
@@ -112,13 +112,17 @@ defmodule PriveeWeb.PriveeSelectorLive do
   end
 
   defp subscribe_to_events(%{assigns: %{current_session: current_session}} = socket) do
-    case Events.subscribe_to_receiving_events(socket, current_session.id) do
-      :ok ->
-        socket
+    if connected?(socket) do
+      case Events.subscribe_to_receiving_events(socket, current_session.id) do
+        :ok ->
+          socket
 
-      error ->
-        Logger.warning("Could not subscribe to receiving events '#{inspect(error)}'.")
-        socket
+        error ->
+          Logger.warning("Could not subscribe to receiving events '#{inspect(error)}'.")
+          socket
+      end
+    else
+      socket
     end
   end
 end

--- a/apps/privee_web/lib/privee_web/live/session_login_live.ex
+++ b/apps/privee_web/lib/privee_web/live/session_login_live.ex
@@ -21,6 +21,7 @@ defmodule PriveeWeb.SessionLoginLive do
           type="text"
           label="Session Name"
           placeholder="Write your session name."
+          phx-debounce="500"
           required
         />
 
@@ -30,6 +31,7 @@ defmodule PriveeWeb.SessionLoginLive do
           label="Recovery phrase"
           placeholder="Your citation."
           rows="5"
+          phx-debounce="1000"
           required
         />
 

--- a/apps/privee_web/lib/privee_web/live/session_registration_live.ex
+++ b/apps/privee_web/lib/privee_web/live/session_registration_live.ex
@@ -4,6 +4,7 @@ defmodule PriveeWeb.SessionRegistrationLive do
   alias Privee.Sessions
   alias Privee.Sessions.Session
 
+  @impl true
   def render(assigns) do
     ~H"""
     <div class="mx-auto sm:max-w-sm md:max-w-md">
@@ -39,9 +40,11 @@ defmodule PriveeWeb.SessionRegistrationLive do
 
         <.input
           field={@form[:session_name]}
-          type="text"
+          type="search"
           label="Session Name"
-          placeholder="Write your session name."
+          placeholder="Write your own session name"
+          value={@automatic_session_name}
+          phx-debounce="1000"
           required
         />
 
@@ -51,6 +54,7 @@ defmodule PriveeWeb.SessionRegistrationLive do
           label="Recovery phrase"
           placeholder="Write your preferred citation. This will be used to recover the session, so keep it saved."
           rows="5"
+          phx-debounce="1000"
           required
         />
 
@@ -62,17 +66,20 @@ defmodule PriveeWeb.SessionRegistrationLive do
     """
   end
 
+  @impl true
   def mount(_params, _session, socket) do
     changeset = Sessions.change_session_registration(%Session{})
 
     socket =
       socket
       |> assign(trigger_submit: false, check_errors: false)
+      |> assign_automatic_session_name()
       |> assign_form(changeset)
 
     {:ok, socket, temporary_assigns: [form: nil]}
   end
 
+  @impl true
   def handle_event("save", %{"session" => session_params}, socket) do
     case Sessions.register_session(session_params) do
       {:ok, session} ->
@@ -91,8 +98,9 @@ defmodule PriveeWeb.SessionRegistrationLive do
     end
   end
 
+  @impl true
   def handle_event("validate", %{"session" => session_params}, socket) do
-    changeset = Sessions.change_session_registration(%Session{}, session_params)
+    changeset = Sessions.change_session_registration(%Session{}, session_params) |> IO.inspect(label: "validation changeset")
     {:noreply, assign_form(socket, Map.put(changeset, :action, :validate))}
   end
 
@@ -103,6 +111,15 @@ defmodule PriveeWeb.SessionRegistrationLive do
       assign(socket, form: form, check_errors: false)
     else
       assign(socket, form: form)
+    end
+  end
+
+  defp assign_automatic_session_name(socket) do
+    if connected?(socket) do
+      automatic_session_name = Sessions.generate_new_available_session_name()
+      assign(socket, :automatic_session_name, automatic_session_name)
+    else
+      assign(socket, :automatic_session_name, "")
     end
   end
 end

--- a/apps/privee_web/lib/privee_web/live/session_registration_live.ex
+++ b/apps/privee_web/lib/privee_web/live/session_registration_live.ex
@@ -3,6 +3,7 @@ defmodule PriveeWeb.SessionRegistrationLive do
 
   alias Privee.Sessions
   alias Privee.Sessions.Session
+  alias Privee.SessionNameProvider
 
   @impl true
   def render(assigns) do
@@ -116,7 +117,7 @@ defmodule PriveeWeb.SessionRegistrationLive do
 
   defp assign_automatic_session_name(socket) do
     if connected?(socket) do
-      automatic_session_name = Sessions.generate_new_available_session_name()
+      {:ok, automatic_session_name} = SessionNameProvider.generate_new_available_session_name()
       assign(socket, :automatic_session_name, automatic_session_name)
     else
       assign(socket, :automatic_session_name, "")

--- a/apps/privee_web/lib/privee_web/live/session_registration_live.ex
+++ b/apps/privee_web/lib/privee_web/live/session_registration_live.ex
@@ -1,9 +1,9 @@
 defmodule PriveeWeb.SessionRegistrationLive do
   use PriveeWeb, :live_view
 
+  alias Privee.SessionNameProvider
   alias Privee.Sessions
   alias Privee.Sessions.Session
-  alias Privee.SessionNameProvider
 
   @impl true
   def render(assigns) do
@@ -101,7 +101,9 @@ defmodule PriveeWeb.SessionRegistrationLive do
 
   @impl true
   def handle_event("validate", %{"session" => session_params}, socket) do
-    changeset = Sessions.change_session_registration(%Session{}, session_params) |> IO.inspect(label: "validation changeset")
+    changeset =
+      Sessions.change_session_registration(%Session{}, session_params)
+
     {:noreply, assign_form(socket, Map.put(changeset, :action, :validate))}
   end
 

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -66,14 +66,14 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
 
     test "creates account and even though the user does not specify the session name", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/sessions/register")
+      mocked_session_name = Privee.SessionNameProvider.Test.get_mocked_unique_session_name()
 
       session_name_input_element =
         lv
         |> element("#session_session_name")
         |> render()
 
-      assert session_name_input_element =~ "value=\""
-      refute session_name_input_element =~ "value=\"\""
+      assert session_name_input_element =~ "value=\"#{mocked_session_name}\""
     end
 
     test "renders errors for duplicated session name", %{conn: conn} do

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -64,6 +64,29 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
       assert response =~ "Log out"
     end
 
+    test "creates account and even though the user does not specify the session name", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/sessions/register")
+
+      recovery_phrase = session_recovery_phrase()
+
+      form =
+        form(lv, "#registration_form",
+          session: %{
+            recovery_phrase: recovery_phrase
+          }
+        )
+
+      render_submit(form)
+      conn = follow_trigger_action(form, conn)
+
+      assert redirected_to(conn) == ~p"/privee"
+
+      # Now do a logged in request and assert on the menu
+      conn = get(conn, "/privee")
+      response = html_response(conn, 200)
+      assert response =~ "Log out"
+    end
+
     test "renders errors for duplicated session name", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/sessions/register")
 

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -67,24 +67,13 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
     test "creates account and even though the user does not specify the session name", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/sessions/register")
 
-      recovery_phrase = session_recovery_phrase()
+      session_name_input_element =
+        lv
+        |> element("#session_session_name")
+        |> render()
 
-      form =
-        form(lv, "#registration_form",
-          session: %{
-            recovery_phrase: recovery_phrase
-          }
-        )
-
-      render_submit(form)
-      conn = follow_trigger_action(form, conn)
-
-      assert redirected_to(conn) == ~p"/privee"
-
-      # Now do a logged in request and assert on the menu
-      conn = get(conn, "/privee")
-      response = html_response(conn, 200)
-      assert response =~ "Log out"
+      assert session_name_input_element =~ "value=\""
+      refute session_name_input_element =~ "value=\"\""
     end
 
     test "renders errors for duplicated session name", %{conn: conn} do

--- a/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
+++ b/apps/privee_web/test/privee_web/live/session_registration_live_test.exs
@@ -4,6 +4,8 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
   import Phoenix.LiveViewTest
   import Privee.SessionsFixtures
 
+  alias Privee.SessionNameProvider.Test
+
   describe "Registration page" do
     test "renders registration page", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/sessions/register")
@@ -64,9 +66,11 @@ defmodule PriveeWeb.SessionRegistrationLiveTest do
       assert response =~ "Log out"
     end
 
-    test "creates account and even though the user does not specify the session name", %{conn: conn} do
+    test "creates account and even though the user does not specify the session name", %{
+      conn: conn
+    } do
       {:ok, lv, _html} = live(conn, ~p"/sessions/register")
-      mocked_session_name = Privee.SessionNameProvider.Test.get_mocked_unique_session_name()
+      mocked_session_name = Test.get_mocked_unique_session_name()
 
       session_name_input_element =
         lv

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,9 @@ config :privee,
 # at the `config/runtime.exs`.
 config :privee, Privee.Mailer, adapter: Swoosh.Adapters.Local
 
+# Selecting the session name provider implementation
+config :privee, :session_name_provider, Privee.SessionNameProvider.Impl
+
 config :privee_web,
   ecto_repos: [Privee.Repo],
   generators: [context_app: :privee]

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,6 +16,9 @@ config :privee, Privee.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 
+# Selecting the session name provider implementation
+config :privee, :session_name_provider, Privee.SessionNameProvider.Test
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :privee_web, PriveeWeb.Endpoint,


### PR DESCRIPTION
Now a new valid session name is automatically generated and applied as a value to the session name form input. The input has been converted to a search input type, so that the user will be able to easily remove the text by clicking on the clear icon.

**Note**: the search solution will not be available on Firefox-based browsers.