### PR TITLE
Added session name to notification for linking

### DIFF
--- a/apps/privee/lib/privee/sessions/message.ex
+++ b/apps/privee/lib/privee/sessions/message.ex
@@ -13,19 +13,21 @@ defmodule Privee.Sessions.Message do
   @type t :: %__MODULE__{
           text: non_neg_integer(),
           from: non_neg_integer(),
-          to: String.t()
+          to: String.t(),
+          sender_session_name: String.t()
         }
 
   embedded_schema do
     field :text, :string
     field :from, :id
     field :to, :id
+    field :sender_session_name, :string
   end
 
   @doc false
   def changeset(%Message{} = message, attrs) do
     message
-    |> cast(attrs, [:text, :from, :to])
-    |> validate_required([:text, :from, :to])
+    |> cast(attrs, [:text, :from, :to, :sender_session_name])
+    |> validate_required([:text, :from, :to, :sender_session_name])
   end
 end

--- a/apps/privee/lib/privee/sessions/message.ex
+++ b/apps/privee/lib/privee/sessions/message.ex
@@ -21,6 +21,7 @@ defmodule Privee.Sessions.Message do
     field :text, :string
     field :from, :id
     field :to, :id
+    # Added to simplify notification handling
     field :sender_session_name, :string
   end
 

--- a/apps/privee_web/assets/js/utils/push-notifications.mjs
+++ b/apps/privee_web/assets/js/utils/push-notifications.mjs
@@ -18,17 +18,25 @@ export const askNotificationPermission = () => {
   
 /**
     * Shows a notification with the given body and an optional title.
-    * @param {string} body - The body of the notification.
+    * @param {string} [body] - The body of the notification.
     * @param {string} [title] - The title of the notification.
+    * @param {string} [url] - The url to open when the notification is clicked.
     * @returns {Promise<?Notification>} - The notification.
     */
-export const pushNotification = (body, title) => {
+export const pushNotification = (body, title, url) => {
   const imageUrl = "/favicon.ico"
   const notificationTitle = title || " - Privee new notification"
 
   const notification = new Notification(notificationTitle, {
     body: body,
     icon: imageUrl
+  })
+
+  // Open the chat when the notification is clicked.
+  notification.addEventListener("click", (_) => {
+    if (url) {
+      window.open(url, "_blank")
+    }
   })
     
   return new Promise((resolve, _reject) => {
@@ -50,6 +58,7 @@ export const pushNotification = (body, title) => {
  * @param {PhoenixEvent} event The event triggered from the back-end.
  */
 export const phoenixPushEventHandler = (event) => {
-  pushNotification(event.detail.text, "Privee - Text received")
+  console.debug("Phoenix event received: ", event)
+  pushNotification(event.detail.text, "Privee - Text received", `/chat/${event.detail.session_name}`)
     .catch(e => console.error("Error showing notification: ", e))
 }

--- a/apps/privee_web/assets/js/utils/push-notifications.mjs
+++ b/apps/privee_web/assets/js/utils/push-notifications.mjs
@@ -58,7 +58,6 @@ export const pushNotification = (body, title, url) => {
  * @param {PhoenixEvent} event The event triggered from the back-end.
  */
 export const phoenixPushEventHandler = (event) => {
-  console.debug("Phoenix event received: ", event)
   pushNotification(event.detail.text, "Privee - Text received", `/chat/${event.detail.session_name}`)
     .catch(e => console.error("Error showing notification: ", e))
 }

--- a/apps/privee_web/lib/privee_web/events.ex
+++ b/apps/privee_web/lib/privee_web/events.ex
@@ -79,7 +79,7 @@ defmodule PriveeWeb.Events do
   end
 
   @doc """
-  Sends a notification event to the client, to trigger in turn a notification. 
+  Sends a notification event to the client, to trigger in turn a notification.
   """
   def send_notification_event_to_client(socket, payload)
 
@@ -90,7 +90,11 @@ defmodule PriveeWeb.Events do
     socket
   end
 
-  def send_notification_event_to_client(socket, %{text: text}) do
-    push_event(socket, @js_event, %{text: text})
+  def send_notification_event_to_client(socket, %{
+    sender_session_name: sender_session_name,
+    text: text
+  } = params) do
+    IO.inspect(params, label: "notification params")
+    push_event(socket, @js_event, %{session_name: sender_session_name, text: text})
   end
 end

--- a/apps/privee_web/lib/privee_web/events.ex
+++ b/apps/privee_web/lib/privee_web/events.ex
@@ -90,11 +90,13 @@ defmodule PriveeWeb.Events do
     socket
   end
 
-  def send_notification_event_to_client(socket, %{
-    sender_session_name: sender_session_name,
-    text: text
-  } = params) do
-    IO.inspect(params, label: "notification params")
+  def send_notification_event_to_client(
+        socket,
+        %{
+          sender_session_name: sender_session_name,
+          text: text
+        }
+      ) do
     push_event(socket, @js_event, %{session_name: sender_session_name, text: text})
   end
 end

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
@@ -46,6 +46,7 @@ defmodule PriveeWeb.Chat.ChatLive do
 
   @impl true
   def handle_event("create", %{"message" => params}, socket) do
+    IO.inspect(params, label: "create params")
     {:noreply,
      socket
      |> deliver_message(params)

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.ex
@@ -46,7 +46,6 @@ defmodule PriveeWeb.Chat.ChatLive do
 
   @impl true
   def handle_event("create", %{"message" => params}, socket) do
-    IO.inspect(params, label: "create params")
     {:noreply,
      socket
      |> deliver_message(params)

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
@@ -21,7 +21,11 @@
 
       <.input type="hidden" field={@form[:to]} value={@selected_session.id} />
 
-      <.input type="hidden" field={@form[:sender_session_name]} value={@current_session.session_name} />
+      <.input
+        type="hidden"
+        field={@form[:sender_session_name]}
+        value={@current_session.session_name}
+      />
 
       <.chat_input form={@form} />
     </.simple_form>

--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
@@ -21,6 +21,8 @@
 
       <.input type="hidden" field={@form[:to]} value={@selected_session.id} />
 
+      <.input type="hidden" field={@form[:sender_session_name]} value={@current_session.session_name} />
+
       <.chat_input form={@form} />
     </.simple_form>
   </footer>


### PR DESCRIPTION
#38 

The notification click now points to the chat the notification refers to. This was achieved by enriching the message sent with the already available session name of the sender, that will be then used when the notification is triggered.