### PR TITLE
Solved adding handler after navigation between LVs

### DIFF
--- a/.devcontainer/install-neovim-tooling.sh
+++ b/.devcontainer/install-neovim-tooling.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-git clone https://codeberg.org/MaxDac/dotfiles.git ~/.dotfiles && \
+git clone https://codeberg.org/MaxDac/dotfiles.git ~/.dotfiles || true && \
 sh ~/.dotfiles/setup-environment.sh && \
 sh ~/.dotfiles/install-neovim-tooling.sh && \
-zsh && \
-asdf plugin add neovim && \
-asdf plugin add tmux && \
-asdf install neovim && \
-asdf install tmux 
+zsh asdf plugin add neovim && \
+zsh asdf plugin add tmux && \
+zsh asdf install neovim && \
+zsh asdf install tmux 

--- a/apps/privee_web/assets/js/app.js
+++ b/apps/privee_web/assets/js/app.js
@@ -30,8 +30,8 @@ import "flowbite/dist/flowbite.phoenix.js"
 // Importing utility functions
 import { addToggleDarkModeHandling, setStartupTheme } from "./utils/dark-mode-switcher.mjs"
 import { askNotificationPermission, phoenixPushEventHandler } from "./utils/push-notifications.mjs"
+import { addSessionNameCopyListener, copyToClipboardBackEndEventHandler } from "./utils/clipboard.mjs"
 import { addChatHooks } from "./hooks/chat-hooks.mjs"
-import { addSessionNameCopyListener, copyToClipboard } from "./utils/clipboard.mjs"
 
 // Setting up LiveView hooks
 const Hooks = {}
@@ -61,7 +61,8 @@ askNotificationPermission()
 
 // Setting the LiveView events
 window.addEventListener("phx:trigger_notification", phoenixPushEventHandler)
-window.addEventListener("phx:copy-to-clipboard", copyToClipboard)
+window.addEventListener("phx:copy-to-clipboard", copyToClipboardBackEndEventHandler)
+
 addSessionNameCopyListener()
 
 // connect if there are any LiveViews on the page

--- a/apps/privee_web/assets/js/hooks/chat-hooks.mjs
+++ b/apps/privee_web/assets/js/hooks/chat-hooks.mjs
@@ -1,3 +1,6 @@
+import { addSessionNameCopyListener } from "../utils/clipboard.mjs"
+import { addDarkModeToggleHandlers } from "../utils/dark-mode-switcher.mjs"
+
 /**
  * Adds hooks to the chat screen to automatically scroll to the bottom of the chat.
  * @param {any} Hooks LiveView Hooks 
@@ -5,6 +8,9 @@
 export function addChatHooks(Hooks) { 
   Hooks.ChatScreen = {
     mounted() {
+      // Readding the event listener for the chat menu buttons.
+      addSessionNameCopyListener()
+      addDarkModeToggleHandlers()
       scrollElementToEnd(this.el)
     },
     updated() {

--- a/apps/privee_web/assets/js/utils/clipboard.mjs
+++ b/apps/privee_web/assets/js/utils/clipboard.mjs
@@ -1,17 +1,10 @@
 /**
-  * @typedef {Object & Event} PhoenixEvent This type represents a custom Phoenix event.
-  * @property {any} detail The event details
-  */
-
-/**
   * Copies the given text into the user clipboard.
-  * @param {PhoenixEvent} [event] The event sent by the back-end.
+  * @param {string} [text] The event sent by the back-end.
   */
-export const copyToClipboard = event => {
-  const text = event.detail.session_name
-
+const copyToClipboard = text => {
   navigator.clipboard.writeText(text)
-    .then(r => console.debug("Session name correctly copied to clipboard.", r))
+    .then(r => console.debug("Session name correctly copied to clipboard.", text, r))
     .catch(error => console.debug("Failed to copy session name to clipboard.", error))
 }
 
@@ -28,9 +21,35 @@ export const addSessionNameCopyListener = () => {
   const copyButtons = getCopyButtons()
 
   copyButtons.forEach(button => {
-    button.addEventListener("click", () => {
-      const sessionName = button.dataset.sessionName
-      copyToClipboard({ detail: { session_name: sessionName } })
-    })
+    button.removeEventListener("click", copyButtonHandler)
+    button.addEventListener("click", copyButtonHandler)
   })
+}
+
+
+/**
+  * @typedef {Object & Event} PhoenixEvent This type represents a custom Phoenix event.
+  * @property {any} detail The event details
+  */
+
+/**
+  * Copies the given text into the user clipboard.
+  * @param {PhoenixEvent} [event] The event sent by the back-end.
+  */
+export const copyToClipboardBackEndEventHandler = event => {
+  const sessionName = event.detail.session_name
+  copyToClipboard(sessionName)
+}
+
+/**
+ * @typedef {Object & Event} ButtonEvent This type represents a custom button event.
+ * @property {HTMLButtonElement} target The button that was clicked.
+ */
+
+/**
+ * Produces a Handler to the click of the copy button click.
+ */
+function copyButtonHandler() {
+  const sessionName = this.dataset.sessionName
+  copyToClipboard(sessionName)
 }

--- a/apps/privee_web/assets/js/utils/dark-mode-switcher.mjs
+++ b/apps/privee_web/assets/js/utils/dark-mode-switcher.mjs
@@ -92,17 +92,30 @@ export const setStartupTheme = () =>
   */
 export const addToggleDarkModeHandling = () => {
   setStartupTheme()
+  addDarkModeToggleHandlers()
+}
 
+/**
+ * Adds the handlers for the buttons that toggle the dark mode theme.
+ */
+export const addDarkModeToggleHandlers = () => {
   const themeToggleButtons = 
     document.querySelectorAll(themeToggleButtonDataThemeToggle)
 
   themeToggleButtons.forEach(themeToggleButton => {
-    themeToggleButton.addEventListener("click", () => {
-      if (isDarkModeEnabled()) {
-        trySetTheme(lightModelLabel)
-      } else {
-        trySetTheme(darkModeLabel)
-      }
-    })
+    themeToggleButton.removeEventListener("click", themeToggleHandler)
+    themeToggleButton.addEventListener("click", themeToggleHandler)
   })
+}
+
+/**
+ * Handles the theme toggle. Not inlined because it has to be removed before
+ * being re-added again to avoid duplications.
+ */
+const themeToggleHandler = () => {
+  if (isDarkModeEnabled()) {
+    trySetTheme(lightModelLabel)
+  } else {
+    trySetTheme(darkModeLabel)
+  }
 }


### PR DESCRIPTION
The LiveView `push_navigate` handler allows changing the LiveView without reconnecting to another socket, having that the LiveViews are in the same `live_session`. This caused the Session menu buttons to not being handled by adding and handler to them when the LiveView changed.

Leveraging the already existing hooks, the functions that added the handlers are now being invoked when the chat component is mounted, and the functions remove the handlers before re-adding them.