### PR TITLE
Adjusted the view height

### DIFF
--- a/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
+++ b/apps/privee_web/lib/privee_web/live/chat/chat_live.html.heex
@@ -1,4 +1,4 @@
-<section class="flex flex-col h-[calc(100vh-80px)] justify-between">
+<section class="flex flex-col h-[calc(100dvh-80px)] justify-between">
   <.header class="h-10 pt-5 pb-10 text-center">
     <%= @selected_session_name %>
   </.header>


### PR DESCRIPTION
#44 

Following [this article](https://tailwindcss.com/blog/tailwindcss-v3-4#dynamic-viewport-units) the view height property `dvh` is used instead of `vh`.

For more information about the possible view heights values in CSS, consult [this article](https://dev.to/frehner/css-vh-dvh-lvh-svh-and-vw-units-27k4).