### PR TITLE
Added viewport config on root

### DIFF
--- a/apps/privee_web/lib/privee_web/components/layouts/root.html.heex
+++ b/apps/privee_web/lib/privee_web/components/layouts/root.html.heex
@@ -2,7 +2,7 @@
 <html lang="en" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <meta name="description" content="Chatting app with focus on privacy" />
     <.live_title suffix=" · Privacy App">


### PR DESCRIPTION
Following [this article](https://www.bram.us/2021/09/13/prevent-items-from-being-hidden-underneath-the-virtual-keyboard-by-means-of-the-virtualkeyboard-api/), the solution applied to the project was to slightly modify the meta viewport value in the root template to add the `interactive-widget=resizes-content` tag.
This allowed the viewport to be automatically resized following the keyboard triggering event.